### PR TITLE
RPE-272:Refactored file name generation logic

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGenerator.java
@@ -2,15 +2,13 @@ package uk.gov.hmcts.reform.slc.services.steps.getpdf;
 
 import uk.gov.hmcts.reform.slc.model.Letter;
 
-import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
-
 public final class FileNameGenerator {
 
     public static String generateFor(
         Letter letter,
         String extension
     ) {
-        return letter.type + "-" + letter.service + "-" + md5Hex(letter.messageId) + "." + extension;
+        return letter.type + "-" + letter.service + "-" + letter.messageId + "." + extension;
     }
 
     private FileNameGenerator() {

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGenerator.java
@@ -1,16 +1,16 @@
 package uk.gov.hmcts.reform.slc.services.steps.getpdf;
 
+import uk.gov.hmcts.reform.slc.model.Letter;
+
 import static org.apache.commons.codec.digest.DigestUtils.md5Hex;
 
 public final class FileNameGenerator {
 
     public static String generateFor(
-        String letterType,
-        String jurisdiction,
-        byte[] content,
+        Letter letter,
         String extension
     ) {
-        return letterType + "-" + jurisdiction + "-" + md5Hex(content) + "." + extension;
+        return letter.type + "-" + letter.service + "-" + md5Hex(letter.messageId) + "." + extension;
     }
 
     private FileNameGenerator() {

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGenerator.java
@@ -8,7 +8,7 @@ public final class FileNameGenerator {
         Letter letter,
         String extension
     ) {
-        return letter.type + "-" + letter.service + "-" + letter.messageId + "." + extension;
+        return letter.type + "-" + letter.service + "-" + letter.id + "." + extension;
     }
 
     private FileNameGenerator() {

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGenerator.java
@@ -8,7 +8,7 @@ public final class FileNameGenerator {
         Letter letter,
         String extension
     ) {
-        return letter.type + "-" + letter.service + "-" + letter.id + "." + extension;
+        return letter.type + "_" + letter.service + "_" + letter.id + "." + extension;
     }
 
     private FileNameGenerator() {

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
@@ -43,7 +43,7 @@ public class PdfCreator {
         byte[] finalContent = PdfMerger.mergeDocuments(docs);
 
         return new PdfDoc(
-            FileNameGenerator.generateFor(letter.type, letter.service, finalContent, "pdf"),
+            FileNameGenerator.generateFor(letter, "pdf"),
             finalContent
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGeneratorTest.java
@@ -14,21 +14,22 @@ public class FileNameGeneratorTest {
     @Test
     public void should_generate_file_name_in_expected_format() {
         // given
-        Letter letter = createLetter(UUID.randomUUID(), "typeA", "cmc", "098F6BCD4621D373CADE4E832627B4F6");
+        UUID letterId = UUID.randomUUID();
+        Letter letter = createLetter(letterId, "typeA", "cmc");
 
         // when
         String result = FileNameGenerator.generateFor(letter, "pdf");
 
         // then
-        assertThat(result).matches("typeA-cmc-.*\\.pdf");
+        assertThat(result).isEqualTo("typeA_cmc_" + letterId + ".pdf");
     }
 
     @Test
     public void should_always_generate_the_same_name_for_same_letter() {
         // given
         UUID letterId = UUID.randomUUID();
-        Letter letter1 = createLetter(letterId, "A", "B", "098F6BCD4621D373CADE4E832627B4F6");
-        Letter letter2 = createLetter(letterId, "A", "B", "098F6BCD4621D373CADE4E832627B4F6");
+        Letter letter1 = createLetter(letterId, "A", "B");
+        Letter letter2 = createLetter(letterId, "A", "B");
 
         String result1 = FileNameGenerator.generateFor(letter1, "pdf");
         String result2 = FileNameGenerator.generateFor(letter2, "pdf");
@@ -40,8 +41,8 @@ public class FileNameGeneratorTest {
     @Test
     public void should_generate_different_names_for_different_letters() {
         // given
-        Letter letter1 = createLetter(UUID.randomUUID(), "A", "B", "5A105E8B9D40E1329780D62EA2265D8A");
-        Letter letter2 = createLetter(UUID.randomUUID(), "A", "B", "AD0234829205B9033196BA818F7A872B");
+        Letter letter1 = createLetter(UUID.randomUUID(), "A", "B");
+        Letter letter2 = createLetter(UUID.randomUUID(), "C", "D");
 
         String result1 = FileNameGenerator.generateFor(letter1, "pdf");
         String result2 = FileNameGenerator.generateFor(letter2, "pdf");
@@ -53,8 +54,8 @@ public class FileNameGeneratorTest {
     @Test
     public void should_generate_different_names_for_same_letters_with_different_id() {
         // given
-        Letter letter1 = createLetter(UUID.randomUUID(), "A", "B", "5A105E8B9D40E1329780D62EA2265D8A");
-        Letter letter2 = createLetter(UUID.randomUUID(), "A", "B", "5A105E8B9D40E1329780D62EA2265D8A");
+        Letter letter1 = createLetter(UUID.randomUUID(), "A", "B");
+        Letter letter2 = createLetter(UUID.randomUUID(), "A", "B");
 
         String result1 = FileNameGenerator.generateFor(letter1, "pdf");
         String result2 = FileNameGenerator.generateFor(letter2, "pdf");
@@ -63,13 +64,13 @@ public class FileNameGeneratorTest {
         assertThat(result1).isNotEqualTo(result2);
     }
 
-    private Letter createLetter(UUID id, String type, String service, String messageId) {
+    private Letter createLetter(UUID id, String type, String service) {
         return new Letter(
             id,
             emptyList(),
             type,
             service,
-            messageId,
+            "098F6BCD4621D373CADE4E832627B4F6",
             emptyMap()
         );
     }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGeneratorTest.java
@@ -1,7 +1,12 @@
 package uk.gov.hmcts.reform.slc.services.steps.getpdf;
 
 import org.junit.Test;
+import uk.gov.hmcts.reform.slc.model.Letter;
 
+import java.util.UUID;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FileNameGeneratorTest {
@@ -9,13 +14,10 @@ public class FileNameGeneratorTest {
     @Test
     public void should_generate_file_name_in_expected_format() {
         // given
-        String letterType = "typeA";
-        String jurisdiction = "cmc";
-        byte[] content = "hello".getBytes();
-        String extension = "pdf";
+        Letter letter = createLetter("typeA", "cmc", "098F6BCD4621D373CADE4E832627B4F6");
 
         // when
-        String result = FileNameGenerator.generateFor(letterType, jurisdiction, content, extension);
+        String result = FileNameGenerator.generateFor(letter, "pdf");
 
         // then
         assertThat(result).matches("typeA-cmc-.*\\.pdf");
@@ -23,20 +25,38 @@ public class FileNameGeneratorTest {
 
     @Test
     public void should_always_generate_the_same_name_for_same_input() {
+        // given
+        Letter letter1 = createLetter("A", "B", "098F6BCD4621D373CADE4E832627B4F6");
+        Letter letter2 = createLetter("A", "B", "098F6BCD4621D373CADE4E832627B4F6");
 
-        String result1 = FileNameGenerator.generateFor("A", "B", "C".getBytes(), "pdf");
-        String result2 = FileNameGenerator.generateFor("A", "B", "C".getBytes(), "pdf");
+        String result1 = FileNameGenerator.generateFor(letter1, "pdf");
+        String result2 = FileNameGenerator.generateFor(letter2, "pdf");
 
         // then
         assertThat(result1).isEqualTo(result2);
     }
 
     @Test
-    public void should_generate_different_names_for_different_file_contents() {
-        String result1 = FileNameGenerator.generateFor("A", "B", "some_content".getBytes(), "pdf");
-        String result2 = FileNameGenerator.generateFor("A", "B", "completely_different_content".getBytes(), "pdf");
+    public void should_generate_different_names_for_different_message_id() {
+        // given
+        Letter letter1 = createLetter("A", "B", "5A105E8B9D40E1329780D62EA2265D8A");
+        Letter letter2 = createLetter("A", "B", "AD0234829205B9033196BA818F7A872B");
+
+        String result1 = FileNameGenerator.generateFor(letter1, "pdf");
+        String result2 = FileNameGenerator.generateFor(letter2, "pdf");
 
         // then
         assertThat(result1).isNotEqualTo(result2);
+    }
+
+    private Letter createLetter(String type, String service, String messageId) {
+        return new Letter(
+            UUID.randomUUID(),
+            emptyList(),
+            type,
+            service,
+            messageId,
+            emptyMap()
+        );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameGeneratorTest.java
@@ -14,7 +14,7 @@ public class FileNameGeneratorTest {
     @Test
     public void should_generate_file_name_in_expected_format() {
         // given
-        Letter letter = createLetter("typeA", "cmc", "098F6BCD4621D373CADE4E832627B4F6");
+        Letter letter = createLetter(UUID.randomUUID(), "typeA", "cmc", "098F6BCD4621D373CADE4E832627B4F6");
 
         // when
         String result = FileNameGenerator.generateFor(letter, "pdf");
@@ -24,10 +24,11 @@ public class FileNameGeneratorTest {
     }
 
     @Test
-    public void should_always_generate_the_same_name_for_same_input() {
+    public void should_always_generate_the_same_name_for_same_letter() {
         // given
-        Letter letter1 = createLetter("A", "B", "098F6BCD4621D373CADE4E832627B4F6");
-        Letter letter2 = createLetter("A", "B", "098F6BCD4621D373CADE4E832627B4F6");
+        UUID letterId = UUID.randomUUID();
+        Letter letter1 = createLetter(letterId, "A", "B", "098F6BCD4621D373CADE4E832627B4F6");
+        Letter letter2 = createLetter(letterId, "A", "B", "098F6BCD4621D373CADE4E832627B4F6");
 
         String result1 = FileNameGenerator.generateFor(letter1, "pdf");
         String result2 = FileNameGenerator.generateFor(letter2, "pdf");
@@ -37,10 +38,10 @@ public class FileNameGeneratorTest {
     }
 
     @Test
-    public void should_generate_different_names_for_different_message_id() {
+    public void should_generate_different_names_for_different_letters() {
         // given
-        Letter letter1 = createLetter("A", "B", "5A105E8B9D40E1329780D62EA2265D8A");
-        Letter letter2 = createLetter("A", "B", "AD0234829205B9033196BA818F7A872B");
+        Letter letter1 = createLetter(UUID.randomUUID(), "A", "B", "5A105E8B9D40E1329780D62EA2265D8A");
+        Letter letter2 = createLetter(UUID.randomUUID(), "A", "B", "AD0234829205B9033196BA818F7A872B");
 
         String result1 = FileNameGenerator.generateFor(letter1, "pdf");
         String result2 = FileNameGenerator.generateFor(letter2, "pdf");
@@ -49,9 +50,22 @@ public class FileNameGeneratorTest {
         assertThat(result1).isNotEqualTo(result2);
     }
 
-    private Letter createLetter(String type, String service, String messageId) {
+    @Test
+    public void should_generate_different_names_for_same_letters_with_different_id() {
+        // given
+        Letter letter1 = createLetter(UUID.randomUUID(), "A", "B", "5A105E8B9D40E1329780D62EA2265D8A");
+        Letter letter2 = createLetter(UUID.randomUUID(), "A", "B", "5A105E8B9D40E1329780D62EA2265D8A");
+
+        String result1 = FileNameGenerator.generateFor(letter1, "pdf");
+        String result2 = FileNameGenerator.generateFor(letter2, "pdf");
+
+        // then
+        assertThat(result1).isNotEqualTo(result2);
+    }
+
+    private Letter createLetter(UUID id, String type, String service, String messageId) {
         return new Letter(
-            UUID.randomUUID(),
+            id,
             emptyList(),
             type,
             service,


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-272

### Change description ###

- Refactored logic to use message checksum instead of file bytes so that it can later used while reconciling reports.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```