### PR TITLE
Added call to update  is_failed status when letter is sent to dead letter queue

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterClient.java
@@ -66,4 +66,15 @@ public class SendLetterClient {
             logger.error("Exception occurred while updating printed_at time for letter id = " + status.id, exception);
         }
     }
+
+    public void updateIsFailedStatus(UUID letterId) {
+        try {
+            restTemplate.put(sendLetterProducerUrl + letterId + "/is-failed", null);
+        } catch (RestClientException exception) {
+            logger.error(
+                "Exception occurred while updating is failed status for letter id = " + letterId,
+                exception
+            );
+        }
+    }
 }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterService.java
@@ -58,6 +58,8 @@ public class SendLetterService {
             //update producer with is_failed status for reporting
             if (Objects.nonNull(letter)) {
                 sendLetterClient.updateIsFailedStatus(letter.id);
+            } else {
+                logger.error("Unable to update is_failed status in producer for reporting");
             }
 
             return FAILURE;

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterService.java
@@ -11,6 +11,8 @@ import uk.gov.hmcts.reform.slc.services.steps.getpdf.PdfDoc;
 import uk.gov.hmcts.reform.slc.services.steps.maptoletter.LetterMapper;
 import uk.gov.hmcts.reform.slc.services.steps.sftpupload.FtpClient;
 
+import java.util.Objects;
+
 import static uk.gov.hmcts.reform.slc.services.servicebus.MessageHandlingResult.FAILURE;
 import static uk.gov.hmcts.reform.slc.services.servicebus.MessageHandlingResult.SUCCESS;
 
@@ -54,7 +56,9 @@ public class SendLetterService {
             logger.error(exc.getMessage(), exc.getCause());
 
             //update producer with is_failed status for reporting
-            sendLetterClient.updateIsFailedStatus(letter.id);
+            if (Objects.nonNull(letter)) {
+                sendLetterClient.updateIsFailedStatus(letter.id);
+            }
 
             return FAILURE;
         }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterService.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterService.java
@@ -37,8 +37,10 @@ public class SendLetterService {
     }
 
     public MessageHandlingResult send(IMessage msg) {
+        Letter letter = null;
+
         try {
-            Letter letter = letterMapper.from(msg);
+            letter = letterMapper.from(msg);
             PdfDoc pdf = pdfCreator.create(letter);
             // TODO: encrypt & sign
             ftpClient.upload(pdf);
@@ -50,6 +52,9 @@ public class SendLetterService {
 
         } catch (Exception exc) {
             logger.error(exc.getMessage(), exc.getCause());
+
+            //update producer with is_failed status for reporting
+            sendLetterClient.updateIsFailedStatus(letter.id);
 
             return FAILURE;
         }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateIsFailedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateIsFailedTest.java
@@ -11,7 +11,6 @@ import uk.gov.hmcts.reform.slc.services.SendLetterClient;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-import static org.apache.commons.lang3.StringUtils.removeEnd;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.ThrowableAssert.catchThrowable;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
@@ -33,36 +32,17 @@ public class UpdateIsFailedTest {
 
     private static final ZonedDateTime now = ZonedDateTime.now();
 
+    private SendLetterClient sendLetterClient;
+
     @Before
     public void setUp() {
         mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+        sendLetterClient = new SendLetterClient(restTemplate, sendLetterProducerUrl, () -> now);
     }
 
     @Test
-    public void should_successfully_put_is_failed_attribute_when_base_url_contains_slash_suffixed() {
+    public void should_successfully_put_is_failed_attribute() {
         //given
-        SendLetterClient sendLetterClient = new SendLetterClient(restTemplate, sendLetterProducerUrl, () -> now);
-
-        mockServer.expect(requestTo(sendLetterProducerUrl + letterId + IS_FAILED))
-            .andExpect(method(HttpMethod.PUT))
-            .andRespond(withStatus(HttpStatus.OK));
-
-        //when
-        sendLetterClient.updateIsFailedStatus(letterId);
-
-        //then
-        mockServer.verify();
-    }
-
-    @Test
-    public void should_successfully_put_is_failed_attribute_when_base_url_contains_no_slash_suffixed() {
-        //given
-        SendLetterClient sendLetterClient = new SendLetterClient(
-            restTemplate,
-            removeEnd(sendLetterProducerUrl, "/"),
-            () -> now
-        );
-
         mockServer.expect(requestTo(sendLetterProducerUrl + letterId + IS_FAILED))
             .andExpect(method(HttpMethod.PUT))
             .andRespond(withStatus(HttpStatus.OK));
@@ -77,8 +57,6 @@ public class UpdateIsFailedTest {
     @Test
     public void should_not_throw_exception_when_rest_template_throws_server_error() {
         //given
-        SendLetterClient sendLetterClient = new SendLetterClient(restTemplate, sendLetterProducerUrl, () -> now);
-
         mockServer.expect(requestTo(sendLetterProducerUrl + letterId + IS_FAILED))
             .andExpect(method(HttpMethod.PUT))
             .andRespond(withServerError());

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateIsFailedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateIsFailedTest.java
@@ -1,0 +1,96 @@
+package uk.gov.hmcts.reform.slc.services.sendletterclient;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+import uk.gov.hmcts.reform.slc.services.SendLetterClient;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+import static org.apache.commons.lang3.StringUtils.removeEnd;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.ThrowableAssert.catchThrowable;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+
+public class UpdateIsFailedTest {
+
+    private MockRestServiceServer mockServer;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    private static final UUID letterId = UUID.randomUUID();
+
+    private static final String sendLetterProducerUrl = "http://localhost:5432/";
+
+    private static final String IS_FAILED = "/is-failed";
+
+    private static final ZonedDateTime now = ZonedDateTime.now();
+
+    @Before
+    public void setUp() {
+        mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+    }
+
+    @Test
+    public void should_successfully_put_is_failed_attribute_when_base_url_contains_slash_suffixed() {
+        //given
+        SendLetterClient sendLetterClient = new SendLetterClient(restTemplate, sendLetterProducerUrl, () -> now);
+
+        mockServer.expect(requestTo(sendLetterProducerUrl + letterId + IS_FAILED))
+            .andExpect(method(HttpMethod.PUT))
+            .andRespond(withStatus(HttpStatus.OK));
+
+        //when
+        sendLetterClient.updateIsFailedStatus(letterId);
+
+        //then
+        mockServer.verify();
+    }
+
+    @Test
+    public void should_successfully_put_is_failed_attribute_when_base_url_contains_no_slash_suffixed() {
+        //given
+        SendLetterClient sendLetterClient = new SendLetterClient(
+            restTemplate,
+            removeEnd(sendLetterProducerUrl, "/"),
+            () -> now
+        );
+
+        mockServer.expect(requestTo(sendLetterProducerUrl + letterId + IS_FAILED))
+            .andExpect(method(HttpMethod.PUT))
+            .andRespond(withStatus(HttpStatus.OK));
+
+        //when
+        sendLetterClient.updateIsFailedStatus(letterId);
+
+        //then
+        mockServer.verify();
+    }
+
+    @Test
+    public void should_not_throw_exception_when_rest_template_throws_server_error() {
+        //given
+        SendLetterClient sendLetterClient = new SendLetterClient(restTemplate, sendLetterProducerUrl, () -> now);
+
+        mockServer.expect(requestTo(sendLetterProducerUrl + letterId + IS_FAILED))
+            .andExpect(method(HttpMethod.PUT))
+            .andRespond(withServerError());
+
+        //when
+        Throwable exception = catchThrowable(() -> {
+            sendLetterClient.updateIsFailedStatus(letterId);
+        });
+
+        //then
+        assertThat(exception).isNull();
+
+        mockServer.verify();
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-283

### Change description ###

- Added call to update `is_failed` column in letter database to true when letter is sent to dead letter queue.

- Added unit test cases.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```