### PR TITLE
Add custom health endpoint

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/ServiceHealthIndicator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/ServiceHealthIndicator.java
@@ -1,0 +1,17 @@
+package uk.gov.hmcts.reform.slc;
+
+import org.springframework.boot.actuate.health.AbstractHealthIndicator;
+import org.springframework.boot.actuate.health.Health;
+
+/**
+ * Never create as a bean as it will automatically include in Actuator list of health indicators.
+ */
+public class ServiceHealthIndicator extends AbstractHealthIndicator {
+
+    @Override
+    protected void doHealthCheck(Health.Builder builder) throws Exception {
+        // TODO implement for smoke tests
+
+        builder.up();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/slc/config/HealthEndpointConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/config/HealthEndpointConfiguration.java
@@ -29,7 +29,8 @@ public class HealthEndpointConfiguration {
     }
 
     /**
-     * Overriding health mvc endpoint bean to be able to include custom service health endpoint
+     * Overriding health mvc endpoint bean to be able to include custom service health endpoint.
+     *
      * @param delegate Integration for endpoint call
      * @return Custom health endpoints
      */

--- a/src/main/java/uk/gov/hmcts/reform/slc/config/HealthEndpointConfiguration.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/config/HealthEndpointConfiguration.java
@@ -1,0 +1,53 @@
+package uk.gov.hmcts.reform.slc.config;
+
+import org.springframework.boot.actuate.autoconfigure.EndpointWebMvcManagementContextConfiguration;
+import org.springframework.boot.actuate.autoconfigure.HealthMvcEndpointProperties;
+import org.springframework.boot.actuate.autoconfigure.ManagementContextConfiguration;
+import org.springframework.boot.actuate.autoconfigure.ManagementServerProperties;
+import org.springframework.boot.actuate.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.HealthMvcEndpoint;
+import org.springframework.boot.actuate.health.HealthAggregator;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import uk.gov.hmcts.reform.slc.ServiceHealthIndicator;
+import uk.gov.hmcts.reform.slc.endpoint.ServiceHealthEndpoint;
+import uk.gov.hmcts.reform.slc.endpoint.ServiceHealthMvcEndpoint;
+
+import java.util.Map;
+
+@AutoConfigureBefore(EndpointWebMvcManagementContextConfiguration.class)
+@ConditionalOnProperty(prefix = "management.health", name = "service.enabled")
+@ManagementContextConfiguration
+public class HealthEndpointConfiguration {
+
+    @Bean
+    public ServiceHealthEndpoint serviceHealthEndpoint(HealthAggregator aggregator,
+                                                       Map<String, HealthIndicator> healthIndicators) {
+        return new ServiceHealthEndpoint(aggregator, healthIndicators, new ServiceHealthIndicator());
+    }
+
+    /**
+     * Overriding health mvc endpoint bean to be able to include custom service health endpoint
+     * @param delegate Integration for endpoint call
+     * @return Custom health endpoints
+     */
+    @Bean
+    @ConditionalOnEnabledEndpoint("health")
+    public HealthMvcEndpoint healthMvcEndpoint(ServiceHealthEndpoint delegate,
+                                               ManagementServerProperties managementServerProperties,
+                                               HealthMvcEndpointProperties healthMvcEndpointProperties) {
+        HealthMvcEndpoint healthMvcEndpoint = new ServiceHealthMvcEndpoint(
+            delegate,
+            managementServerProperties.getSecurity().isEnabled(),
+            managementServerProperties.getSecurity().getRoles()
+        );
+
+        if (healthMvcEndpointProperties.getMapping() != null) {
+            healthMvcEndpoint.addStatusMapping(healthMvcEndpointProperties.getMapping());
+        }
+
+        return healthMvcEndpoint;
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/slc/endpoint/ServiceHealthEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/endpoint/ServiceHealthEndpoint.java
@@ -1,0 +1,31 @@
+package uk.gov.hmcts.reform.slc.endpoint;
+
+import org.springframework.boot.actuate.endpoint.HealthEndpoint;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthAggregator;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import uk.gov.hmcts.reform.slc.ServiceHealthIndicator;
+
+import java.util.Map;
+
+@ConfigurationProperties(prefix = "endpoints.health")
+public class ServiceHealthEndpoint extends HealthEndpoint {
+
+    private final ServiceHealthIndicator serviceHealthIndicator;
+
+    /**
+     * Create a new {@link ServiceHealthEndpoint} instance.
+     */
+    public ServiceHealthEndpoint(HealthAggregator aggregator,
+                                 Map<String, HealthIndicator> healthIndicators,
+                                 ServiceHealthIndicator serviceHealthIndicator) {
+        super(aggregator, healthIndicators);
+
+        this.serviceHealthIndicator = serviceHealthIndicator;
+    }
+
+    public Health checkHealth() {
+        return serviceHealthIndicator.health();
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/slc/endpoint/ServiceHealthMvcEndpoint.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/endpoint/ServiceHealthMvcEndpoint.java
@@ -1,0 +1,33 @@
+package uk.gov.hmcts.reform.slc.endpoint;
+
+import org.springframework.boot.actuate.endpoint.mvc.ActuatorMediaTypes;
+import org.springframework.boot.actuate.endpoint.mvc.HealthMvcEndpoint;
+import org.springframework.boot.actuate.endpoint.mvc.HypermediaDisabled;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "endpoints.health")
+public class ServiceHealthMvcEndpoint extends HealthMvcEndpoint {
+
+    public ServiceHealthMvcEndpoint(ServiceHealthEndpoint delegate, boolean secure, List<String> roles) {
+        super(delegate, secure, roles);
+    }
+
+    @GetMapping(value = "/service", produces = {
+        ActuatorMediaTypes.APPLICATION_ACTUATOR_V1_JSON_VALUE,
+        MediaType.APPLICATION_JSON_VALUE
+    })
+    @ResponseBody
+    @HypermediaDisabled
+    public Object serviceHealth() {
+        if (!getDelegate().isEnabled()) {
+            return getDisabledResponse();
+        }
+
+        return ((ServiceHealthEndpoint) getDelegate()).checkHealth();
+    }
+}

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.actuate.autoconfigure.ManagementContextConfiguration=\
+uk.gov.hmcts.reform.slc.config.HealthEndpointConfiguration

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,6 +2,9 @@ server:
   port: 8486
 
 management:
+  health:
+    service:
+      enabled: true
   security:
     enabled: ${MANAGEMENT_SECURITY_ENABLED:true}
 


### PR DESCRIPTION
### Change description ###

This extends default health check endpoint. Default integration still works as is including custom endpoint `/health/service` which can be used to check internal components to be healthy.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
