### PR TITLE
Retrieve s2s secret from the same place as s2s gets it from

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -3,7 +3,7 @@ provider "vault" {
 }
 
 data "vault_generic_secret" "s2s_secret" {
-  path = "secret/${var.vault_section}/cc/send-letter-consumer/s2s-secret"
+  path = "secret/${var.vault_section}/ccidam/service-auth-provider/api/microservice-keys/send-letter-consumer"
 }
 
 data "vault_generic_secret" "ftp_user" {


### PR DESCRIPTION
### Change description ###

Retrieve s2s secret from the same place as s2s gets it from. Before this change we stored the secret in two places (two Vault paths), but there's no need for it.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
