### PR TITLE
Remove not used `additionalData` field from `Letter` model

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/model/Letter.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/model/Letter.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.hibernate.validator.constraints.NotEmpty;
 
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 import javax.validation.constraints.NotNull;
 
@@ -25,21 +24,17 @@ public class Letter {
     @NotEmpty
     public final String messageId;
 
-    public final Map<String, Object> additionalData;
-
     public Letter(
         @JsonProperty("id") UUID id,
         @JsonProperty("documents") List<Document> documents,
         @JsonProperty("type") String type,
         @JsonProperty("service") String service,
-        @JsonProperty("message_id") String messageId,
-        @JsonProperty("additional_data") Map<String, Object> additionalData
+        @JsonProperty("message_id") String messageId
     ) {
         this.id = id;
         this.documents = documents;
         this.type = type;
         this.service = service;
         this.messageId = messageId;
-        this.additionalData = additionalData;
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/SendLetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/SendLetterServiceTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.slc.services;
 
-import com.google.common.collect.ImmutableMap;
 import com.microsoft.azure.servicebus.IMessage;
 import org.junit.Before;
 import org.junit.Test;
@@ -79,11 +78,7 @@ public class SendLetterServiceTest {
             ),
             "some_type",
             "cmc",
-            "some-service-bus-id",
-            ImmutableMap.of(
-                "case_id", "asd7efwy8ef",
-                "document_type", "claim"
-            )
+            "some-service-bus-id"
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameHelperTest.java
@@ -6,7 +6,6 @@ import uk.gov.hmcts.reform.slc.model.Letter;
 import java.util.UUID;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -88,8 +87,7 @@ public class FileNameHelperTest {
             emptyList(),
             type,
             service,
-            "098F6BCD4621D373CADE4E832627B4F6",
-            emptyMap()
+            "098F6BCD4621D373CADE4E832627B4F6"
         );
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreatorTest.java
@@ -1,6 +1,5 @@
 package uk.gov.hmcts.reform.slc.services.steps.getpdf;
 
-import com.google.common.collect.ImmutableMap;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.junit.Before;
 import org.junit.Test;
@@ -82,10 +81,7 @@ public class PdfCreatorTest {
             ),
             "type",
             "service",
-            "3h9j8e",
-            ImmutableMap.of(
-                "case_id", "asd38r"
-            )
+            "3h9j8e"
         );
 
         // when
@@ -121,10 +117,7 @@ public class PdfCreatorTest {
             ),
             "type",
             "service",
-            "a97gss8as",
-            ImmutableMap.of(
-                "foo", "bar"
-            )
+            "a97gss8as"
         );
 
         assertThatThrownBy(() -> pdfCreator.create(letter))

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/LetterMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/LetterMapperTest.java
@@ -54,10 +54,7 @@ public class LetterMapperTest {
                     + "],"
                     + "\"type\": \"some_type\","
                     + "\"service\": \"some_service\","
-                    + "\"message_id\": \"syf8f7\","
-                    + "\"additional_data\": {"
-                    + "  \"document_type\": \"claim\""
-                    + "}"
+                    + "\"message_id\": \"syf8f7\""
                     + "}"
                 ).getBytes()
             );


### PR DESCRIPTION
I'll update producer next as well to not put this on a queue.