### PR TITLE
sonar config fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -80,6 +80,7 @@ sonarqube {
     property "sonar.projectName", "Reform :: Send Letter Consumer"
     property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
     property "sonar.jacoco.itReportPath", "${project.buildDir}/jacoco/functional.exec"
+    property "sonar.coverage.exclusions", "**/src/main/java/uk/gov/hmcts/reform/slc/config/**"
   }
 }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'send-letter-consumer-service'


### PR DESCRIPTION
- specify project name
- exclude config classes from coverage reports