### PR TITLE
Stop retrieving producer's URL from Vault

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -22,10 +22,6 @@ data "vault_generic_secret" "servicebus_conn_string" {
   path = "secret/${var.vault_section}/cc/send-letter/servicebus-listen-conn-string"
 }
 
-data "vault_generic_secret" "send_letter_producer_url" {
-  path = "secret/${var.vault_section}/cc/send-letter/producer-url"
-}
-
 locals {
   aseName = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
 }


### PR DESCRIPTION
### Change description ###

Stop retrieving producer's URL from Vault. Is was invalid and now the consumer prepares it itself.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
