### PR TITLE
delete csv reports

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterClient.java
@@ -67,17 +67,13 @@ public class SendLetterClient {
     }
 
     public void updatePrintedAt(LetterPrintStatus status) {
-        try {
-            restTemplatePut(
-                sendLetterProducerUrl + status.id + "/printed-at",
-                ImmutableMap.of(
-                    "printed_at",
-                    status.printedAt.format(ISO_INSTANT)
-                )
-            );
-        } catch (RestClientException exception) {
-            logger.error("Exception occurred while updating printed_at time for letter id = " + status.id, exception);
-        }
+        restTemplatePut(
+            sendLetterProducerUrl + status.id + "/printed-at",
+            ImmutableMap.of(
+                "printed_at",
+                status.printedAt.format(ISO_INSTANT)
+            )
+        );
     }
 
     public void updateIsFailedStatus(UUID letterId) {

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/UpdateLetterStatusJob.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/UpdateLetterStatusJob.java
@@ -42,7 +42,7 @@ public class UpdateLetterStatusJob {
                 .map(parser::parse)
                 .forEach(parsedReport -> {
                     parsedReport.statuses.forEach(sendLetterClient::updatePrintedAt);
-                    // TODO: delete report
+                    ftpClient.deleteReport(parsedReport.path);
                 });
         } else {
             logger.trace("FTP server not available, job cancelled");

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClient.java
@@ -94,6 +94,17 @@ public class FtpClient {
         });
     }
 
+    public void deleteReport(String reportPath) {
+        runWith(sftp -> {
+            try {
+                sftp.rm(reportPath);
+                return null;
+            } catch (Exception exc) {
+                throw new FtpStepException("Error while deleting report: " + reportPath, exc);
+            }
+        });
+    }
+
     public void testConnection() {
         runWith(sftpClient -> null);
     }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/UpdateLetterStatusJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/UpdateLetterStatusJobTest.java
@@ -11,8 +11,6 @@ import uk.gov.hmcts.reform.slc.services.steps.sftpupload.FtpClient;
 import uk.gov.hmcts.reform.slc.services.steps.sftpupload.ParsedReport;
 import uk.gov.hmcts.reform.slc.services.steps.sftpupload.Report;
 
-import java.util.Collections;
-
 import static java.time.ZonedDateTime.now;
 import static java.util.Arrays.asList;
 import static java.util.Collections.singletonList;

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/UpdateLetterStatusJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/UpdateLetterStatusJobTest.java
@@ -5,10 +5,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.web.client.RestClientException;
+import uk.gov.hmcts.reform.slc.model.LetterPrintStatus;
 import uk.gov.hmcts.reform.slc.services.steps.sftpupload.FtpClient;
+import uk.gov.hmcts.reform.slc.services.steps.sftpupload.ParsedReport;
+import uk.gov.hmcts.reform.slc.services.steps.sftpupload.Report;
 
+import java.util.Collections;
+
+import static java.time.ZonedDateTime.now;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.catchThrowable;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -44,5 +56,45 @@ public class UpdateLetterStatusJobTest {
         job.run();
 
         verify(ftpClient, times(1)).downloadReports();
+    }
+
+    @Test
+    public void should_not_remove_report_if_parsing_failed() {
+        // given
+        given(ftpAvailabilityChecker.isFtpAvailable(any())).willReturn(true);
+        given(ftpClient.downloadReports()).willReturn(singletonList(new Report("FROM/1.csv", null)));
+        given(parser.parse(any())).willThrow(new ReportParser.ReportParsingException(null));
+
+        // when
+        catchThrowable(() -> job.run());
+
+        // then
+        verify(ftpClient, times(0)).deleteReport(anyString());
+    }
+
+    @Test
+    public void should_not_remove_report_if_sending_updates_failed() {
+        // given
+        given(ftpAvailabilityChecker.isFtpAvailable(any())).willReturn(true);
+        given(ftpClient.downloadReports())
+            .willReturn(singletonList(new Report("FROM/1.csv", null)));
+        given(parser.parse(any()))
+            .willReturn(
+                new ParsedReport(
+                    "FROM/1.csv",
+                    asList(
+                        new LetterPrintStatus("abc", now()),
+                        new LetterPrintStatus("xyz", now())
+                    )
+                )
+            );
+
+        willThrow(RestClientException.class).given(sendLetterClient).updatePrintedAt(any());
+
+        // when
+        catchThrowable(() -> job.run());
+
+        // then
+        verify(ftpClient, times(0)).deleteReport(anyString());
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/UpdateLetterStatusJobTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/UpdateLetterStatusJobTest.java
@@ -95,4 +95,31 @@ public class UpdateLetterStatusJobTest {
         // then
         verify(ftpClient, times(0)).deleteReport(anyString());
     }
+
+    @Test
+    public void should_delete_file_if_parsing_and_api_calls_succeeded() {
+        // given
+        String filePath = "FROM/1.csv";
+        given(ftpAvailabilityChecker.isFtpAvailable(any())).willReturn(true);
+
+        given(ftpClient.downloadReports())
+            .willReturn(singletonList(new Report(filePath, null)));
+
+        given(parser.parse(any()))
+            .willReturn(
+                new ParsedReport(
+                    filePath,
+                    asList(
+                        new LetterPrintStatus("abc", now()),
+                        new LetterPrintStatus("xyz", now())
+                    )
+                )
+            );
+
+        // when
+        job.run();
+
+        // then
+        verify(ftpClient, times(1)).deleteReport(filePath);
+    }
 }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdatePrintedAtTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdatePrintedAtTest.java
@@ -64,7 +64,7 @@ public class UpdatePrintedAtTest {
     }
 
     @Test
-    public void should_not_throw_exception_when_server_responds_with_an_error() {
+    public void should_throw_exception_when_server_responds_with_an_error() {
         String id = "f36e834a-216c-48ed-8fe9-b0dabc4daa49";
 
         mockServer
@@ -74,7 +74,7 @@ public class UpdatePrintedAtTest {
 
         Throwable exception = catchThrowable(() -> client.updatePrintedAt(new LetterPrintStatus(id, now())));
 
-        assertThat(exception).isNull();
+        assertThat(exception).isNotNull();
 
         mockServer.verify();
     }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClientTest.java
@@ -167,4 +167,19 @@ public class FtpClientTest {
 
         assertThat(exc).isNotNull();
     }
+
+    @Test
+    public void deleteReports_should_throw_an_exception_if_deleting_file_failed() throws Exception {
+        // given
+        doThrow(IOException.class)
+            .when(sftpClient).rm("hello.csv");
+
+        // when
+        Throwable exc = catchThrowable(() -> client.deleteReport("hello.csv"));
+
+        // then
+        assertThat(exc)
+            .isInstanceOf(FtpStepException.class)
+            .hasMessageContaining("Error while deleting report");
+    }
 }


### PR DESCRIPTION
If everything went fine with parsing csv and updating letter status in the api, remove the file.
Otherwise don't.

You may notice while reviewing that in case of multiple csv, if the first one fails the whole job stops.
This will be fixed in a future pull request.