### PR TITLE
Fix send letter client api url

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/SendLetterClient.java
@@ -32,18 +32,22 @@ public class SendLetterClient {
     private static final Logger logger = LoggerFactory.getLogger(SendLetterService.class);
 
     private final RestTemplate restTemplate;
+    private final String sendLetterUrl;
     private final String sendLetterProducerUrl;
     private final Supplier<ZonedDateTime> currentDateTimeSupplier;
     private final AuthTokenGenerator authTokenGenerator;
 
     public SendLetterClient(
         RestTemplate restTemplate,
-        @Value("${sendletter.producer.url}") String sendLetterProducerUrl,
+        @Value("${sendletter.producer.url}") String sendLetterUrl,
         Supplier<ZonedDateTime> currentDateTimeSupplier,
         AuthTokenGenerator authTokenGenerator
     ) {
+        String appendedUrl = appendIfMissing(sendLetterUrl, "/");
+
         this.restTemplate = restTemplate;
-        this.sendLetterProducerUrl = appendIfMissing(sendLetterProducerUrl, "/");
+        this.sendLetterUrl = appendedUrl;
+        this.sendLetterProducerUrl = appendedUrl + "letters/";
         this.currentDateTimeSupplier = currentDateTimeSupplier;
         this.authTokenGenerator = authTokenGenerator;
     }
@@ -95,7 +99,7 @@ public class SendLetterClient {
     public Health serviceHealthy() {
         try {
             ResponseEntity<InternalHealth> response = restTemplate
-                .getForEntity(sendLetterProducerUrl + "health", InternalHealth.class);
+                .getForEntity(sendLetterUrl + "health", InternalHealth.class);
 
             return Health.status(response.getBody().getStatus()).build();
         } catch (Exception ex) {

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateIsFailedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateIsFailedTest.java
@@ -34,7 +34,7 @@ public class UpdateIsFailedTest {
 
     private static final String sendLetterProducerUrl = "http://localhost:5432/";
 
-    private static final String IS_FAILED = "/is-failed";
+    private static final String API_URL = sendLetterProducerUrl + "letters/" + letterId + "/is-failed";
 
     private static final String AUTH_HEADER = "service-auth-header";
 
@@ -54,7 +54,7 @@ public class UpdateIsFailedTest {
     @Test
     public void should_successfully_put_is_failed_attribute() {
         //given
-        mockServer.expect(requestTo(sendLetterProducerUrl + letterId + IS_FAILED))
+        mockServer.expect(requestTo(API_URL))
             .andExpect(method(HttpMethod.PUT))
             .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(header(SendLetterClient.AUTHORIZATION_HEADER, AUTH_HEADER))
@@ -70,7 +70,7 @@ public class UpdateIsFailedTest {
     @Test
     public void should_not_throw_exception_when_rest_template_throws_server_error() {
         //given
-        mockServer.expect(requestTo(sendLetterProducerUrl + letterId + IS_FAILED))
+        mockServer.expect(requestTo(API_URL))
             .andExpect(method(HttpMethod.PUT))
             .andRespond(withServerError());
 

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateIsFailedTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateIsFailedTest.java
@@ -30,11 +30,11 @@ public class UpdateIsFailedTest {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    private static final UUID letterId = UUID.randomUUID();
+    private static final UUID LETTER_ID = UUID.randomUUID();
 
-    private static final String sendLetterProducerUrl = "http://localhost:5432/";
+    private static final String PRODUCER_URL = "http://localhost:5432/";
 
-    private static final String API_URL = sendLetterProducerUrl + "letters/" + letterId + "/is-failed";
+    private static final String API_URL = PRODUCER_URL + "letters/" + LETTER_ID + "/is-failed";
 
     private static final String AUTH_HEADER = "service-auth-header";
 
@@ -48,7 +48,7 @@ public class UpdateIsFailedTest {
         when(authTokenGenerator.generate()).thenReturn(AUTH_HEADER);
 
         mockServer = MockRestServiceServer.bindTo(restTemplate).build();
-        sendLetterClient = new SendLetterClient(restTemplate, sendLetterProducerUrl, () -> now, authTokenGenerator);
+        sendLetterClient = new SendLetterClient(restTemplate, PRODUCER_URL, () -> now, authTokenGenerator);
     }
 
     @Test
@@ -61,7 +61,7 @@ public class UpdateIsFailedTest {
             .andRespond(withStatus(HttpStatus.OK));
 
         //when
-        sendLetterClient.updateIsFailedStatus(letterId);
+        sendLetterClient.updateIsFailedStatus(LETTER_ID);
 
         //then
         mockServer.verify();
@@ -76,7 +76,7 @@ public class UpdateIsFailedTest {
 
         //when
         Throwable exception = catchThrowable(() -> {
-            sendLetterClient.updateIsFailedStatus(letterId);
+            sendLetterClient.updateIsFailedStatus(LETTER_ID);
         });
 
         //then

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdatePrintedAtTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdatePrintedAtTest.java
@@ -11,6 +11,7 @@ import uk.gov.hmcts.reform.slc.model.LetterPrintStatus;
 import uk.gov.hmcts.reform.slc.services.SendLetterClient;
 
 import java.time.ZonedDateTime;
+import java.util.UUID;
 
 import static java.time.ZonedDateTime.now;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,8 +29,11 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 public class UpdatePrintedAtTest {
 
+    private static final String LETTER_ID = UUID.randomUUID().toString();
     private static final String AUTH_HEADER = "service-auth-header";
-    private static final String url = "http://localhost/";
+    private static final String PRODUCER_URL = "http://localhost/";
+    private static final String API_URL = PRODUCER_URL + "letters/" + LETTER_ID + "/printed-at";
+
     private final RestTemplate restTemplate = new RestTemplate();
 
     private MockRestServiceServer mockServer;
@@ -41,16 +45,15 @@ public class UpdatePrintedAtTest {
         when(authTokenGenerator.generate()).thenReturn(AUTH_HEADER);
 
         mockServer = MockRestServiceServer.bindTo(restTemplate).build();
-        client = new SendLetterClient(restTemplate, url, ZonedDateTime::now, authTokenGenerator);
+        client = new SendLetterClient(restTemplate, PRODUCER_URL, ZonedDateTime::now, authTokenGenerator);
     }
 
     @Test
     public void should_send_valid_request() {
-        String id = "f36e834a-216c-48ed-8fe9-b0dabc4daa49";
         String datetime = "2018-01-01T21:11:00Z";
 
         mockServer
-            .expect(requestTo(url + id + "/printed-at"))
+            .expect(requestTo(API_URL))
             .andExpect(method(PUT))
             .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(header(SendLetterClient.AUTHORIZATION_HEADER, AUTH_HEADER))
@@ -58,21 +61,19 @@ public class UpdatePrintedAtTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
             .andRespond(withStatus(NO_CONTENT));
 
-        client.updatePrintedAt(new LetterPrintStatus(id, ZonedDateTime.parse(datetime)));
+        client.updatePrintedAt(new LetterPrintStatus(LETTER_ID, ZonedDateTime.parse(datetime)));
 
         mockServer.verify();
     }
 
     @Test
     public void should_throw_exception_when_server_responds_with_an_error() {
-        String id = "f36e834a-216c-48ed-8fe9-b0dabc4daa49";
-
         mockServer
-            .expect(requestTo(url + id + "/printed-at"))
+            .expect(requestTo(API_URL))
             .andExpect(method(PUT))
             .andRespond(withServerError());
 
-        Throwable exception = catchThrowable(() -> client.updatePrintedAt(new LetterPrintStatus(id, now())));
+        Throwable exception = catchThrowable(() -> client.updatePrintedAt(new LetterPrintStatus(LETTER_ID, now())));
 
         assertThat(exception).isNotNull();
 

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdatePrintedAtTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdatePrintedAtTest.java
@@ -29,9 +29,12 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 public class UpdatePrintedAtTest {
 
-    private static final String LETTER_ID = UUID.randomUUID().toString();
+    private static final UUID LETTER_ID = UUID.randomUUID();
+
     private static final String AUTH_HEADER = "service-auth-header";
+
     private static final String PRODUCER_URL = "http://localhost/";
+
     private static final String API_URL = PRODUCER_URL + "letters/" + LETTER_ID + "/printed-at";
 
     private final RestTemplate restTemplate = new RestTemplate();
@@ -61,7 +64,7 @@ public class UpdatePrintedAtTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
             .andRespond(withStatus(NO_CONTENT));
 
-        client.updatePrintedAt(new LetterPrintStatus(LETTER_ID, ZonedDateTime.parse(datetime)));
+        client.updatePrintedAt(new LetterPrintStatus(LETTER_ID.toString(), ZonedDateTime.parse(datetime)));
 
         mockServer.verify();
     }
@@ -73,7 +76,9 @@ public class UpdatePrintedAtTest {
             .andExpect(method(PUT))
             .andRespond(withServerError());
 
-        Throwable exception = catchThrowable(() -> client.updatePrintedAt(new LetterPrintStatus(LETTER_ID, now())));
+        Throwable exception = catchThrowable(() ->
+            client.updatePrintedAt(new LetterPrintStatus(LETTER_ID.toString(), now()))
+        );
 
         assertThat(exception).isNotNull();
 

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateSentToPrintAtTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateSentToPrintAtTest.java
@@ -32,11 +32,11 @@ public class UpdateSentToPrintAtTest {
 
     private final RestTemplate restTemplate = new RestTemplate();
 
-    private static final UUID letterId = UUID.randomUUID();
+    private static final UUID LETTER_ID = UUID.randomUUID();
 
-    private static final String sendLetterProducerUrl = "http://localhost:5432/";
+    private static final String PRODUCER_URL = "http://localhost:5432/";
 
-    private static final String API_URL = sendLetterProducerUrl + "letters/" + letterId + "/sent-to-print-at";
+    private static final String API_URL = PRODUCER_URL + "letters/" + LETTER_ID + "/sent-to-print-at";
 
     private static final String AUTH_HEADER = "service-auth-header";
 
@@ -53,7 +53,7 @@ public class UpdateSentToPrintAtTest {
 
         isoDate = now.format(DateTimeFormatter.ISO_INSTANT);
         mockServer = MockRestServiceServer.bindTo(restTemplate).build();
-        sendLetterClient = new SendLetterClient(restTemplate, sendLetterProducerUrl, () -> now, authTokenGenerator);
+        sendLetterClient = new SendLetterClient(restTemplate, PRODUCER_URL, () -> now, authTokenGenerator);
     }
 
     @Test
@@ -68,7 +68,7 @@ public class UpdateSentToPrintAtTest {
             .andRespond(withStatus(HttpStatus.OK));
 
         //when
-        sendLetterClient.updateSentToPrintAt(letterId);
+        sendLetterClient.updateSentToPrintAt(LETTER_ID);
 
         //then
         mockServer.verify();
@@ -82,7 +82,7 @@ public class UpdateSentToPrintAtTest {
             .andRespond(withServerError());
 
         //when
-        Throwable exception = catchThrowable(() -> sendLetterClient.updateSentToPrintAt(letterId));
+        Throwable exception = catchThrowable(() -> sendLetterClient.updateSentToPrintAt(LETTER_ID));
 
         //then
         assertThat(exception).isNull();

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateSentToPrintAtTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/sendletterclient/UpdateSentToPrintAtTest.java
@@ -34,9 +34,9 @@ public class UpdateSentToPrintAtTest {
 
     private static final UUID letterId = UUID.randomUUID();
 
-    private static final String SENT_TO_PRINT_AT = "/sent-to-print-at";
-
     private static final String sendLetterProducerUrl = "http://localhost:5432/";
+
+    private static final String API_URL = sendLetterProducerUrl + "letters/" + letterId + "/sent-to-print-at";
 
     private static final String AUTH_HEADER = "service-auth-header";
 
@@ -59,7 +59,7 @@ public class UpdateSentToPrintAtTest {
     @Test
     public void should_successfully_put_sent_to_print_at_attribute() {
         //given
-        mockServer.expect(requestTo(sendLetterProducerUrl + letterId + SENT_TO_PRINT_AT))
+        mockServer.expect(requestTo(API_URL))
             .andExpect(header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_UTF8_VALUE))
             .andExpect(header(SendLetterClient.AUTHORIZATION_HEADER, AUTH_HEADER))
             .andExpect(content().string("{\"sent_to_print_at\":\"" + isoDate + "\"}"))
@@ -77,7 +77,7 @@ public class UpdateSentToPrintAtTest {
     @Test
     public void should_not_throw_exception_when_rest_template_throw_server_error() {
         //given
-        mockServer.expect(requestTo(sendLetterProducerUrl + letterId + SENT_TO_PRINT_AT))
+        mockServer.expect(requestTo(API_URL))
             .andExpect(method(HttpMethod.PUT))
             .andRespond(withServerError());
 


### PR DESCRIPTION
### Change description ###

Health check and resource specific api calls used same service url. Assigning both urls and using them accordingly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
