### PR TITLE
Make s2s url environment-specific

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -40,7 +40,7 @@ module "consumer" {
     PDF_SERVICE_URL = "http://cmc-pdf-service-${var.env}.service.${local.aseName}.internal"
 
     // s2s
-    S2S_URL     = "http://betadevbccidams2slb.reform.hmcts.net:80"
+    S2S_URL     = "${var.s2s_url}"
     S2S_SECRET  = "${data.vault_generic_secret.s2s_secret.data["value"]}"
     S2S_NAME    = "${var.s2s_name}"
 

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,1 +1,2 @@
 vault_section = "prod"
+s2s_url = "https://prod-s2s-api.reform.hmcts.net:3511"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -26,6 +26,10 @@ variable "s2s_name" {
   default = "sendletterconsumer"
 }
 
+variable "s2s_url" {
+  default = "http://betadevbccidams2slb.reform.hmcts.net:80"
+}
+
 variable "service_bus_interval" {
   default = "30000"
 }


### PR DESCRIPTION
### Change description ###

Make s2s url environment-specific. Currently, it refers to the dev instance from each environment.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
