### PR TITLE
Fix microservice name to match the one on s2s side

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -23,7 +23,7 @@ variable "ilbIp" {}
 # region app config
 
 variable "s2s_name" {
-  default = "sendletterconsumer"
+  default = "send_letter_consumer"
 }
 
 variable "s2s_url" {


### PR DESCRIPTION
### Change description ###

Fix microservice name to match the one on s2s side

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
