### PR TITLE
Handle underscores when extracting id from file name

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameHelper.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameHelper.java
@@ -13,10 +13,10 @@ public final class FileNameHelper {
 
     public static String extractId(String fileName) {
         String[] parts = FilenameUtils.removeExtension(fileName).split(SEPARATOR);
-        if (parts.length != 3) {
+        if (parts.length < 3) {
             throw new UnableToExtractIdFromFileNameException();
         } else {
-            return parts[2];
+            return parts[parts.length - 1];
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameHelperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/FileNameHelperTest.java
@@ -5,6 +5,7 @@ import uk.gov.hmcts.reform.slc.model.Letter;
 
 import java.util.UUID;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -66,12 +67,18 @@ public class FileNameHelperTest {
 
     @Test
     public void should_extract_letter_id_from_file_name() {
-        Letter letter = createLetter(UUID.randomUUID(), "type", "cmc");
-        String name = FileNameHelper.generateName(letter, "pdf");
+        asList(
+            createLetter(UUID.randomUUID(), "type", "cmc"),
+            createLetter(UUID.randomUUID(), "smoke_test", "cmc"),
+            createLetter(UUID.randomUUID(), "type", "my_service_"),
+            createLetter(UUID.randomUUID(), "some_type", "my_service")
+        ).forEach(letter -> {
+            String name = FileNameHelper.generateName(letter, "pdf");
 
-        String extractedId = FileNameHelper.extractId(name);
+            String extractedId = FileNameHelper.extractId(name);
 
-        assertThat(extractedId).isEqualTo(letter.id.toString());
+            assertThat(extractedId).isEqualTo(letter.id.toString());
+        });
     }
 
     @Test


### PR DESCRIPTION
for example `smoke_test` letters... 