### PR TITLE
Switch to S2S instances from CNP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -155,7 +155,7 @@ dependencies {
   compile group: 'uk.gov.hmcts.reform', name: 'http-proxy-spring-boot-autoconfigure', version: '1.1.0'
 
   compile group: 'uk.gov.hmcts.reform', name: 'pdf-service-client', version: '5.0.0'
-  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.4.2'
+  compile group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: '0.5.2'
 
   compile group: 'ch.qos.logback', name: 'logback-classic', version: versions.logback
   compile group: 'ch.qos.logback', name: 'logback-core', version: versions.logback

--- a/infrastructure/demo.tfvars
+++ b/infrastructure/demo.tfvars
@@ -1,2 +1,1 @@
 vault_section = "preprod"
-s2s_url = "https://preprod-s2s-api.reform.hmcts.net:3511"

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -24,6 +24,7 @@ data "vault_generic_secret" "servicebus_conn_string" {
 
 locals {
   aseName = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+  s2s_url = "http://rpe-service-auth-provider-${var.env}.service.${local.aseName}.internal"
 }
 
 module "consumer" {
@@ -40,7 +41,7 @@ module "consumer" {
     PDF_SERVICE_URL = "http://cmc-pdf-service-${var.env}.service.${local.aseName}.internal"
 
     // s2s
-    S2S_URL     = "${var.s2s_url}"
+    S2S_URL     = "${local.s2s_url}"
     S2S_SECRET  = "${data.vault_generic_secret.s2s_secret.data["value"]}"
     S2S_NAME    = "${var.s2s_name}"
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -23,8 +23,8 @@ data "vault_generic_secret" "servicebus_conn_string" {
 }
 
 locals {
-  aseName = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
-  s2s_url = "http://rpe-service-auth-provider-${var.env}.service.${local.aseName}.internal"
+  ase_name = "${data.terraform_remote_state.core_apps_compute.ase_name[0]}"
+  s2s_url = "http://rpe-service-auth-provider-${var.env}.service.${local.ase_name}.internal"
 }
 
 module "consumer" {
@@ -38,7 +38,7 @@ module "consumer" {
   app_settings = {
 
     // pdf
-    PDF_SERVICE_URL = "http://cmc-pdf-service-${var.env}.service.${local.aseName}.internal"
+    PDF_SERVICE_URL = "http://cmc-pdf-service-${var.env}.service.${local.ase_name}.internal"
 
     // s2s
     S2S_URL     = "${local.s2s_url}"
@@ -58,7 +58,7 @@ module "consumer" {
     FTP_REPORTS_FOLDER        = "${var.ftp_reports_folder}"
     FTP_REPORTS_CRON          = "${var.ftp_reports_cron}"
     FTP_USER                  = "${data.vault_generic_secret.ftp_user.data["value"]}"
-    SEND_LETTER_PRODUCER_URL  = "http://send-letter-producer-${var.env}.service.${local.aseName}.internal"
+    SEND_LETTER_PRODUCER_URL  = "http://send-letter-producer-${var.env}.service.${local.ase_name}.internal"
     FTP_PRIVATE_KEY           = "${replace(data.vault_generic_secret.ftp_private_key.data["value"], "\\n", "\n")}"
     FTP_PUBLIC_KEY            = "${replace(data.vault_generic_secret.ftp_public_key.data["value"], "\\n", "\n")}"
   }

--- a/infrastructure/prod.tfvars
+++ b/infrastructure/prod.tfvars
@@ -1,2 +1,1 @@
 vault_section = "prod"
-s2s_url = "https://prod-s2s-api.reform.hmcts.net:3511"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -15,7 +15,7 @@ variable "env" {
 variable "vault_section" {
   type = "string"
   description = "Name of the environment-specific section in Vault key path, i.e. secret/{vault_section}/..."
-  default = "dev"
+  default = "test"
 }
 
 variable "ilbIp" {}
@@ -24,10 +24,6 @@ variable "ilbIp" {}
 
 variable "s2s_name" {
   default = "send_letter_consumer"
-}
-
-variable "s2s_url" {
-  default = "http://betadevaccidams2slb.reform.hmcts.net:80"
 }
 
 variable "service_bus_interval" {


### PR DESCRIPTION
### Change description ###

Switch to S2S instances from CNP and use the same vault paths as those instances use.

Can't be merged in until S2S refreshes microservice keys from Vault and Jenkins gets the right access to Vault.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
