### PR TITLE
Clean up model

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfDoc.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfDoc.java
@@ -1,11 +1,6 @@
 package uk.gov.hmcts.reform.slc.services.steps.getpdf;
 
-import net.schmizz.sshj.xfer.InMemorySourceFile;
-
-import java.io.ByteArrayInputStream;
-import java.io.InputStream;
-
-public class PdfDoc extends InMemorySourceFile {
+public class PdfDoc {
 
     public final String filename;
     public final byte[] content;
@@ -13,20 +8,5 @@ public class PdfDoc extends InMemorySourceFile {
     public PdfDoc(String filename, byte[] content) {
         this.filename = filename;
         this.content = content;
-    }
-
-    @Override
-    public String getName() {
-        return this.filename;
-    }
-
-    @Override
-    public long getLength() {
-        return this.content.length;
-    }
-
-    @Override
-    public InputStream getInputStream() {
-        return new ByteArrayInputStream(this.content);
     }
 }


### PR DESCRIPTION
It no longer needs to extend SSHJ base class (we now send .zip instead .pdf to SFTP)