### PR TITLE
Update java logging

### DIFF
--- a/bin/run-in-docker.sh
+++ b/bin/run-in-docker.sh
@@ -8,25 +8,25 @@ print_help() {
   ./run-in-docker.sh [OPTIONS]
 
   Options:
-    --clean, -c                   Clean and install current state of source code
-    --install, -i                 Install current state of source code
-    --param PARAM=, -p PARAM=     Parse script parameter
-    --help, -h                    Print this help block
+    --clean, -c                     Clean and install current state of source code
+    --install, -i                   Install current state of source code
+    --param PARAM=, -p PARAM=       Parse script parameter
+    --help, -h                      Print this help block
 
   Available parameters:
-    APPLICATION_INSIGHTS_IKEY     Defaults to '00000000-0000-0000-0000-000000000000'
-    FTP_FINGERPRINT               Defaults to 'fingerprint'
-    FTP_HOSTNAME                  Defaults to 'hostname'
-    FTP_PORT                      Defaults to '22'
-    FTP_PRIVATE_KEY               Defaults to 'private'
-    FTP_PUBLIC_KEY                Defaults to 'public'
-    FTP_REPORTS_FOLDER            Defaults to '/reports/'
-    FTP_TARGET_FOLDER             Defaults to '/target/'
-    FTP_USER                      Defaults to 'user'
-    PDF_SERVICE_URL               Defaults to 'http://localhost:5500'
-    S2S_SECRET                    Defaults to 'secret'
-    S2S_URL                       Defaults to 'false' - disables health check
-    SEND_LETTER_PRODUCER_URL      Defaults to 'http://localhost:8485'
+    APPINSIGHTS_INSTRUMENTATIONKEY  Defaults to '00000000-0000-0000-0000-000000000000'
+    FTP_FINGERPRINT                 Defaults to 'fingerprint'
+    FTP_HOSTNAME                    Defaults to 'hostname'
+    FTP_PORT                        Defaults to '22'
+    FTP_PRIVATE_KEY                 Defaults to 'private'
+    FTP_PUBLIC_KEY                  Defaults to 'public'
+    FTP_REPORTS_FOLDER              Defaults to '/reports/'
+    FTP_TARGET_FOLDER               Defaults to '/target/'
+    FTP_USER                        Defaults to 'user'
+    PDF_SERVICE_URL                 Defaults to 'http://localhost:5500'
+    S2S_SECRET                      Defaults to 'secret'
+    S2S_URL                         Defaults to 'false' - disables health check
+    SEND_LETTER_PRODUCER_URL        Defaults to 'http://localhost:8485'
   "
 }
 
@@ -35,7 +35,7 @@ GRADLE_CLEAN=false
 GRADLE_INSTALL=false
 
 # environment variables
-APPLICATION_INSIGHTS_IKEY="00000000-0000-0000-0000-000000000000"
+APPINSIGHTS_INSTRUMENTATIONKEY="00000000-0000-0000-0000-000000000000"
 FTP_FINGERPRINT="fingerprint"
 FTP_HOSTNAME="hostname"
 FTP_PORT=22
@@ -66,7 +66,7 @@ execute_script() {
 
   echo "Assigning environment variables.."
 
-  export APPLICATION_INSIGHTS_IKEY=${APPLICATION_INSIGHTS_IKEY}
+  export APPINSIGHTS_INSTRUMENTATIONKEY=${APPINSIGHTS_INSTRUMENTATIONKEY}
   export FTP_FINGERPRINT=${FTP_FINGERPRINT}
   export FTP_HOSTNAME=${FTP_HOSTNAME}
   export FTP_PORT=${FTP_PORT}
@@ -92,7 +92,7 @@ while true ; do
     -i|--install) GRADLE_INSTALL=true ; shift ;;
     -p|--param)
       case "$2" in
-        APPLICATION_INSIGHTS_IKEY=*) APPLICATION_INSIGHTS_IKEY="${2#*=}" ; shift 2 ;;
+        APPINSIGHTS_INSTRUMENTATIONKEY=*) APPINSIGHTS_INSTRUMENTATIONKEY="${2#*=}" ; shift 2 ;;
         FTP_FINGERPRINT=*) FTP_FINGERPRINT="${2#*=}" ; shift 2 ;;
         FTP_HOSTNAME=*) FTP_HOSTNAME="${2#*=}" ; shift 2 ;;
         FTP_PORT=*) FTP_PORT="${2#*=}" ; shift 2 ;;

--- a/build.gradle
+++ b/build.gradle
@@ -183,4 +183,8 @@ dependencies {
 
 jar {
   archiveName 'send-letter-consumer-service.jar'
+
+  manifest {
+    attributes('Implementation-Version': project.version.toString())
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ task integration(type: Test, group: 'Verification') {
   testClassesDirs = sourceSets.integrationTest.output.classesDirs
   classpath = sourceSets.integrationTest.runtimeClasspath
 
-  environment("APPLICATION_INSIGHTS_IKEY", "test-key")
+  environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
 }
 
 task smoke(type: Test) {
@@ -135,7 +135,7 @@ repositories {
 
 def versions = [
   springBoot: plugins.getPlugin('org.springframework.boot').class.package.implementationVersion,
-  reformLogging: '1.6.1',
+  reformLogging: '2.0.2',
   hystrix: '1.4.0.RELEASE',
   logback: '1.2.3'
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     image: docker.artifactory.reform.hmcts.net/reform/send-letter-consumer-service
     container_name: send-letter-consumer-service
     environment:
-      - APPLICATION_INSIGHTS_IKEY
+      - APPINSIGHTS_INSTRUMENTATIONKEY
       - FTP_FINGERPRINT
       - FTP_HOSTNAME
       - FTP_PORT

--- a/src/main/java/uk/gov/hmcts/reform/slc/logging/ErrorCode.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/logging/ErrorCode.java
@@ -1,7 +1,0 @@
-package uk.gov.hmcts.reform.slc.logging;
-
-@SuppressWarnings({"squid:S1118", "HideUtilityClassConstructor"})
-public final class ErrorCode {
-
-    public static final String UNKNOWN = "UNKNOWN";
-}

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/exceptions/ConnectionException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/exceptions/ConnectionException.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.slc.services.servicebus.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
-import static uk.gov.hmcts.reform.slc.logging.ErrorCode.UNKNOWN;
-
-public class ConnectionException extends AbstractLoggingException {
+public class ConnectionException extends UnknownErrorCodeException {
     public ConnectionException(String message, Throwable cause) {
-        super(AlertLevel.P1, UNKNOWN, message, cause);
+        super(AlertLevel.P1, message, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/exceptions/PdfMergeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/exceptions/PdfMergeException.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.slc.services.servicebus.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
-import static uk.gov.hmcts.reform.slc.logging.ErrorCode.UNKNOWN;
-
-public class PdfMergeException extends AbstractLoggingException {
+public class PdfMergeException extends UnknownErrorCodeException {
     public PdfMergeException(String message, Throwable cause) {
-        super(AlertLevel.P2, UNKNOWN, message, cause);
+        super(AlertLevel.P2, message, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/duplex/DuplexException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/duplex/DuplexException.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.slc.services.steps.getpdf.duplex;
 
-import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
-import static uk.gov.hmcts.reform.slc.logging.ErrorCode.UNKNOWN;
-
-public class DuplexException extends AbstractLoggingException {
+public class DuplexException extends UnknownErrorCodeException {
     public DuplexException(Throwable cause) {
-        super(AlertLevel.P2, UNKNOWN, cause);
+        super(AlertLevel.P2, cause);
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/exceptions/InvalidMessageException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/exceptions/InvalidMessageException.java
@@ -1,14 +1,12 @@
 package uk.gov.hmcts.reform.slc.services.steps.maptoletter.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
-import static uk.gov.hmcts.reform.slc.logging.ErrorCode.UNKNOWN;
-
-public class InvalidMessageException extends AbstractLoggingException {
+public class InvalidMessageException extends UnknownErrorCodeException {
 
     public InvalidMessageException(String message, Throwable cause) {
-        super(AlertLevel.P4, UNKNOWN, message, cause);
+        super(AlertLevel.P4, message, cause);
     }
 
     public InvalidMessageException(String message) {

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/exceptions/FtpStepException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/exceptions/FtpStepException.java
@@ -1,12 +1,10 @@
 package uk.gov.hmcts.reform.slc.services.steps.sftpupload.exceptions;
 
-import uk.gov.hmcts.reform.logging.exception.AbstractLoggingException;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
+import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
-import static uk.gov.hmcts.reform.slc.logging.ErrorCode.UNKNOWN;
-
-public class FtpStepException extends AbstractLoggingException {
+public class FtpStepException extends UnknownErrorCodeException {
     public FtpStepException(String message, Throwable cause) {
-        super(AlertLevel.P1, UNKNOWN, message, cause);
+        super(AlertLevel.P1, message, cause);
     }
 }


### PR DESCRIPTION
Fixes:

- Uses latest java-logging implementation with different AppInsights instrumentation key
- Provide application version used in AppInsights
- Simplify exception construct by using java-logging helper class instead

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
