### PR TITLE
Fix SonarQube error on inheritance

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/exceptions/ConnectionException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/exceptions/ConnectionException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.slc.services.servicebus.exceptions;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
 public class ConnectionException extends UnknownErrorCodeException {
     public ConnectionException(String message, Throwable cause) {
         super(AlertLevel.P1, message, cause);

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/exceptions/PdfMergeException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/exceptions/PdfMergeException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.slc.services.servicebus.exceptions;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
 public class PdfMergeException extends UnknownErrorCodeException {
     public PdfMergeException(String message, Throwable cause) {
         super(AlertLevel.P2, message, cause);

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/duplex/DuplexException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/duplex/DuplexException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.slc.services.steps.getpdf.duplex;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
 public class DuplexException extends UnknownErrorCodeException {
     public DuplexException(Throwable cause) {
         super(AlertLevel.P2, cause);

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/exceptions/InvalidMessageException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/exceptions/InvalidMessageException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.slc.services.steps.maptoletter.exceptions;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
 public class InvalidMessageException extends UnknownErrorCodeException {
 
     public InvalidMessageException(String message, Throwable cause) {

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/exceptions/FtpStepException.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/exceptions/FtpStepException.java
@@ -3,6 +3,10 @@ package uk.gov.hmcts.reform.slc.services.steps.sftpupload.exceptions;
 import uk.gov.hmcts.reform.logging.exception.AlertLevel;
 import uk.gov.hmcts.reform.logging.exception.UnknownErrorCodeException;
 
+/**
+ * SonarQube reports as error. Max allowed - 5 parents
+ */
+@SuppressWarnings("squid:MaximumInheritanceDepth")
 public class FtpStepException extends UnknownErrorCodeException {
     public FtpStepException(String message, Throwable cause) {
         super(AlertLevel.P1, message, cause);


### PR DESCRIPTION
Until we can come up with a way to override limitation of 5 parents this is a quick notice to SonarQube to kindly don't check rule for exception classes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
