### PR TITLE
Add product's Azure Vault to terraform

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -64,3 +64,14 @@ module "consumer" {
     FTP_PUBLIC_KEY            = "${replace(data.vault_generic_secret.ftp_public_key.data["value"], "\\n", "\n")}"
   }
 }
+
+module "key-vault" {
+  source              = "git@github.com:contino/moj-module-key-vault?ref=master"
+  product             = "${var.product}"
+  env                 = "${var.env}"
+  tenant_id           = "${var.tenant_id}"
+  object_id           = "${var.jenkins_AAD_objectId}"
+  resource_group_name = "${var.product}-producer-${var.env}"
+  # dcd_cc-dev group object ID
+  product_group_object_id = "38f9dea6-e861-4a50-9e73-21e64f563537"
+}

--- a/infrastructure/output.tf
+++ b/infrastructure/output.tf
@@ -1,0 +1,7 @@
+output "vaultUri" {
+  value = "${module.key-vault.key_vault_uri}"
+}
+
+output "vaultName" {
+  value = "${module.key-vault.key_vault_name}"
+}

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -61,4 +61,15 @@ variable "ftp_reports_cron" {
 variable "subscription" {
 }
 
+variable "tenant_id" {}
+
+variable "client_id" {
+  description = "(Required) The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. This is usually sourced from environment variables and not normally required to be specified."
+}
+
+variable "jenkins_AAD_objectId" {
+  type        = "string"
+  description = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
+}
+
 # endregion


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RPE-302

### Change description ###

Add Azure Vault for the consumer (the same instance as used by the producer, as it's product-level). Consumer terraform needs this vault to pass connection details to smoke/functional tests running on Jenkins box.

Successful test build:
https://sandbox-build.platform.hmcts.net/job/HMCTS/job/send-letter-consumer-service/job/cnp/28/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
