### PR TITLE
Update job config and add owasp dependency check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,8 @@ version = '0.0.1'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+check.dependsOn dependencyCheckAnalyze
+
 sourceSets {
   functionalTest {
     java {

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -30,8 +30,8 @@ ftp:
   privateKey: ${FTP_PRIVATE_KEY}
   publicKey: ${FTP_PUBLIC_KEY}
   downtime:
-    from: ${FTP_DOWNTIME_FROM:17:00}
-    to: ${FTP_DOWNTIME_TO:18:00}
+    from: ${FTP_DOWNTIME_FROM:16:00}
+    to: ${FTP_DOWNTIME_TO:17:00}
 
 app-insights:
   request-component: off


### PR DESCRIPTION
### Change description ###

- Updated job config time to skip processing of messages between 16.00 and 17.00

- Add a dependency of owasp dependency analyse on check task which will create dependency-check-report.html in reports folder

- Tested on sandbox https://sandbox-build.platform.hmcts.net/job/HMCTS/job/send-letter-consumer-service/job/PR-ADD-DEPENDENCY-CHECK-UPDATE-JOB-CONFIG/5/ but please note that owasp check is not enabled on sandbox so we might have to test it on prod pipeline.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x ] No
```