### PR TITLE
Add additional_host_name terraform variable

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -72,4 +72,8 @@ variable "jenkins_AAD_objectId" {
   description = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."
 }
 
+variable "additional_host_name" {
+  default = "send-letter-consumer.platform.hmcts.net"
+}
+
 # endregion


### PR DESCRIPTION
### Change description ###

Add additional_host_name terraform variable. This variable is now required by the pipeline, which will fail without it.

Successful run on sandbox: https://sandbox-build.platform.hmcts.net/job/HMCTS/job/send-letter-consumer-service/job/cnp/73/

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
