### PR TITLE
Update more info about letter failure to AppInsights

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/slc/logging/AppEvent.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/logging/AppEvent.java
@@ -18,6 +18,11 @@ final class AppEvent {
     static final String MESSAGE_HANDLED_UNSUCCESSFULLY = "MessageHandleFailure";
 
     /**
+     * Failed letter handler process.
+     */
+    static final String LETTER_HANDLED_UNSUCCESSFULLY = "LetterHandleFailure";
+
+    /**
      * Successful message map.
      */
     static final String MESSAGE_MAPPED_SUCCESSFULLY = "MessageMapSuccess";

--- a/src/main/java/uk/gov/hmcts/reform/slc/logging/AppInsights.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/logging/AppInsights.java
@@ -5,8 +5,10 @@ import com.microsoft.applicationinsights.TelemetryClient;
 import com.microsoft.applicationinsights.telemetry.Duration;
 import org.springframework.stereotype.Component;
 import uk.gov.hmcts.reform.logging.appinsights.AbstractAppInsights;
+import uk.gov.hmcts.reform.slc.model.Letter;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static java.util.Collections.singletonMap;
 
@@ -94,8 +96,29 @@ public class AppInsights extends AbstractAppInsights {
         );
     }
 
-    public void trackMessageMappedToLetter(String messageId, String serviceName, String template, long bodyLength) {
+    public void trackLetterNotHandled(Letter letter) {
         Map<String, String> properties = ImmutableMap.of(
+            "letterId", letter.id.toString(),
+            "service", letter.service,
+            "type", letter.type
+        );
+
+        telemetry.trackEvent(
+            AppEvent.LETTER_HANDLED_UNSUCCESSFULLY,
+            properties,
+            singletonMap("numberOfDocuments", (double) letter.documents.size())
+        );
+    }
+
+    public void trackMessageMappedToLetter(
+        UUID letterId,
+        String messageId,
+        String serviceName,
+        String template,
+        long bodyLength
+    ) {
+        Map<String, String> properties = ImmutableMap.of(
+            "letterId", letterId.toString(),
             MESSAGE_ID, messageId,
             "service", serviceName,
             "template", template

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/MessageProcessor.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/servicebus/MessageProcessor.java
@@ -49,14 +49,12 @@ public class MessageProcessor {
 
             logger.info("Finished processing queue");
         } catch (ConnectionException e) {
-            insights.trackException(e);
             logger.error("Unable to connect to Service Bus", e);
         } finally {
             if (messageReceiver != null) {
                 try {
                     messageReceiver.close();
                 } catch (ServiceBusException e) {
-                    insights.trackException(e);
                     logger.error("Error closing connection", e);
                 }
             }
@@ -85,8 +83,8 @@ public class MessageProcessor {
             // TODO: change the event to "MessageReceivingFailed"
             Duration tookReceiving = Duration.between(receiveStartTime, Instant.now());
             insights.trackMessageReceivedFromServiceBus(tookReceiving, false);
-            insights.trackException(e);
             logger.error("Unable to read message from queue", e);
+
             return null;
         }
     }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreator.java
@@ -59,7 +59,6 @@ public class PdfCreator {
             return pdf;
         } catch (PDFServiceClientException exception) {
             insights.trackPdfGenerator(Duration.between(start, Instant.now()), false);
-            insights.trackException(exception);
 
             throw exception;
         }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/LetterMapper.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/LetterMapper.java
@@ -56,7 +56,13 @@ public class LetterMapper {
         }
 
         letter.documents.forEach(document ->
-            insights.trackMessageMappedToLetter(messageId, letter.service, document.template, bodyLength)
+            insights.trackMessageMappedToLetter(
+                letter.id,
+                messageId,
+                letter.service,
+                document.template,
+                bodyLength
+            )
         );
 
         return letter;

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClient.java
@@ -143,7 +143,7 @@ public class FtpClient {
         } catch (IOException exc) {
             insights.trackException(exc);
 
-            throw new FtpStepException("Unable to upload file.", exc);
+            throw new FtpStepException("Unable to connect to ftp.", exc);
         } finally {
             try {
                 if (ssh != null) {

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClient.java
@@ -63,7 +63,6 @@ public class FtpClient {
 
             } catch (IOException exc) {
                 insights.trackFtpUpload(Duration.between(start, Instant.now()), false);
-                insights.trackException(exc);
 
                 throw new FtpStepException("Unable to upload file.", exc);
             }

--- a/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClient.java
+++ b/src/main/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClient.java
@@ -3,6 +3,8 @@ package uk.gov.hmcts.reform.slc.services.steps.sftpupload;
 import net.schmizz.sshj.SSHClient;
 import net.schmizz.sshj.sftp.SFTPClient;
 import net.schmizz.sshj.sftp.SFTPFileTransfer;
+import net.schmizz.sshj.transport.TransportException;
+import net.schmizz.sshj.userauth.UserAuthException;
 import net.schmizz.sshj.xfer.LocalSourceFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,6 +136,10 @@ public class FtpClient {
             try (SFTPClient sftp = ssh.newSFTPClient()) {
                 return action.apply(sftp);
             }
+        } catch (UserAuthException | TransportException exc) {
+            insights.trackException(exc);
+
+            throw new FtpStepException("Unable to authenticate with public key", exc);
         } catch (IOException exc) {
             insights.trackException(exc);
 

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/SendLetterServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/SendLetterServiceTest.java
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import uk.gov.hmcts.reform.pdf.service.client.exception.PDFServiceClientException;
+import uk.gov.hmcts.reform.slc.logging.AppInsights;
 import uk.gov.hmcts.reform.slc.model.Document;
 import uk.gov.hmcts.reform.slc.model.Letter;
 import uk.gov.hmcts.reform.slc.services.servicebus.MessageHandlingResult;
@@ -37,14 +38,15 @@ public class SendLetterServiceTest {
     @Mock private Zipper zipper;
     @Mock private FtpClient ftpClient;
     @Mock private SendLetterClient sendLetterClient;
+    @Mock private AppInsights insights;
 
     @Mock private IMessage message;
 
     private SendLetterService service;
 
     @Before
-    public void setUp() throws Exception {
-        service = new SendLetterService(letterMapper, pdfCreator, zipper, ftpClient, sendLetterClient);
+    public void setUp() {
+        service = new SendLetterService(letterMapper, pdfCreator, zipper, ftpClient, sendLetterClient, insights);
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/servicebus/MessageProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/servicebus/MessageProcessorTest.java
@@ -136,7 +136,6 @@ public class MessageProcessorTest {
         //then
         assertThat(exception).isNull();
 
-        verify(insights).trackException(any(ServiceBusException.class));
         verify(sendLetterService, never()).send(any());
         verifyNoMoreInteractions(insights);
     }
@@ -156,7 +155,6 @@ public class MessageProcessorTest {
         assertThat(exception).isNull();
 
         verify(insights).trackMessageReceivedFromServiceBus(any(Duration.class), eq(false));
-        verify(insights).trackException(any(InterruptedException.class));
         verify(sendLetterService, never()).send(any());
         verifyNoMoreInteractions(insights);
     }
@@ -176,7 +174,6 @@ public class MessageProcessorTest {
         assertThat(exception).isNull();
 
         verify(insights).trackMessageReceivedFromServiceBus(any(Duration.class), eq(false));
-        verify(insights).trackException(any(ServiceBusException.class));
         verify(sendLetterService, never()).send(any());
         verifyNoMoreInteractions(insights);
     }

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/servicebus/MessageProcessorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/servicebus/MessageProcessorTest.java
@@ -129,9 +129,7 @@ public class MessageProcessorTest {
         doThrow(ConnectionException.class).when(receiverProvider).get();
 
         //when
-        Throwable exception = catchThrowable(() -> {
-            processor.process();
-        });
+        Throwable exception = catchThrowable(processor::process);
 
         //then
         assertThat(exception).isNull();
@@ -147,9 +145,7 @@ public class MessageProcessorTest {
         doThrow(InterruptedException.class).when(messageReceiver).receive();
 
         //when
-        Throwable exception = catchThrowable(() -> {
-            processor.process();
-        });
+        Throwable exception = catchThrowable(processor::process);
 
         // then
         assertThat(exception).isNull();
@@ -166,9 +162,7 @@ public class MessageProcessorTest {
         doThrow(ServiceBusException.class).when(messageReceiver).receive();
 
         //when
-        Throwable exception = catchThrowable(() -> {
-            processor.process();
-        });
+        Throwable exception = catchThrowable(processor::process);
 
         // then
         assertThat(exception).isNull();

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreatorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/getpdf/PdfCreatorTest.java
@@ -122,7 +122,6 @@ public class PdfCreatorTest {
             .isInstanceOf(PDFServiceClientException.class);
 
         verify(insights).trackPdfGenerator(any(Duration.class), eq(false));
-        verify(insights).trackException(any(PDFServiceClientException.class));
         verifyNoMoreInteractions(insights);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/LetterMapperTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/maptoletter/LetterMapperTest.java
@@ -66,7 +66,13 @@ public class LetterMapperTest {
         assertThat(letter.service).isEqualTo("some_service");
         assertThat(letter.id).isExactlyInstanceOf(UUID.class);
 
-        verify(insights).trackMessageMappedToLetter(anyString(), eq("some_service"), eq("whatever"), anyLong());
+        verify(insights).trackMessageMappedToLetter(
+            eq(letter.id),
+            anyString(),
+            eq("some_service"),
+            eq("whatever"),
+            anyLong()
+        );
         verifyNoMoreInteractions(insights);
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClientTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/slc/services/steps/sftpupload/FtpClientTest.java
@@ -87,7 +87,6 @@ public class FtpClientTest {
             .hasMessageContaining("upload");
 
         verify(insights).trackFtpUpload(any(Duration.class), eq(false));
-        verify(insights).trackException(any(IOException.class));
     }
 
     @Test


### PR DESCRIPTION
When message is being dead lettered, it is hard to get ID to query stats from producer. And there is no automatic way of getting around this. Additional event is recorded to track letter details.

Bonus exception handling amendments can be found in first 3 commits 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
